### PR TITLE
add body_force option to `motion_t`

### DIFF
--- a/PyPTS/motions.f90
+++ b/PyPTS/motions.f90
@@ -7,7 +7,7 @@ module motions_m
     
 contains
 
-subroutine assign_droplet_motion(dt, L_ref, U_ref, rho_f, mu_f, rho_p, RK_order) bind(c, name="assign_droplet_motion")
+subroutine assign_droplet_motion(dt, L_ref, U_ref, rho_f, mu_f, rho_p, RK_order, body_force) bind(c, name="assign_droplet_motion")
     real(c_double),intent(in) :: dt
     real(c_double),intent(in) :: L_ref
     real(c_double),intent(in) :: U_ref
@@ -15,10 +15,11 @@ subroutine assign_droplet_motion(dt, L_ref, U_ref, rho_f, mu_f, rho_p, RK_order)
     real(c_double),intent(in) :: mu_f
     real(c_double),intent(in) :: rho_p
     integer(c_int),intent(in) :: RK_order
+    real(c_double),intent(in) :: body_force(3)
 
     type(droplet_motion_t) motion_
 
-    call motion_%construct_droplet_motion(dt, L_ref, U_ref, rho_f, mu_f, rho_p, RK_order)
+    call motion_%construct_droplet_motion(dt, L_ref, U_ref, rho_f, mu_f, rho_p, RK_order, body_force)
 
     call mv_simulator%set_motion(motion_)
 

--- a/PyPTS/motions.py
+++ b/PyPTS/motions.py
@@ -28,7 +28,7 @@ def droplet(dt:float, L_ref:float, U_ref:float, rho_f:float, mu_f:float, rho_p:f
                                  ctypes.byref(ctypes.c_double(mu_f)),
                                  ctypes.byref(ctypes.c_double(rho_p)),
                                  ctypes.byref(ctypes.c_int(RK_order)),
-                                 np.array(gravity))
+                                 np.array(gravity, dtype=np.float64))
 
 
     

--- a/PyPTS/motions.py
+++ b/PyPTS/motions.py
@@ -9,12 +9,14 @@ _pypts._pypts_flib.assign_droplet_motion.argtypes = [
                                          ctypes.POINTER(ctypes.c_double),
                                          ctypes.POINTER(ctypes.c_double),
                                          ctypes.POINTER(ctypes.c_double),
-                                         ctypes.POINTER(ctypes.c_int)]
+                                         ctypes.POINTER(ctypes.c_int),
+                                         np.ctypeslib.ndpointer(dtype=np.float64)]
 _pypts._pypts_flib.assign_droplet_motion.restype = None
 
 
 
-def droplet(dt:float, L_ref:float, U_ref:float, rho_f:float, mu_f:float, rho_p:float, RK_order:int) -> None:
+def droplet(dt:float, L_ref:float, U_ref:float, rho_f:float, mu_f:float, rho_p:float, RK_order:int,
+            gravity:list=[0.0, 0.0, -9.806]) -> None:
     """
     droplet motion. 
     """
@@ -25,7 +27,8 @@ def droplet(dt:float, L_ref:float, U_ref:float, rho_f:float, mu_f:float, rho_p:f
                                  ctypes.byref(ctypes.c_double(rho_f)),
                                  ctypes.byref(ctypes.c_double(mu_f)),
                                  ctypes.byref(ctypes.c_double(rho_p)),
-                                 ctypes.byref(ctypes.c_int(RK_order)))
+                                 ctypes.byref(ctypes.c_int(RK_order)),
+                                 np.array(gravity))
 
 
     


### PR DESCRIPTION
粒子の体積力を`motion_t`のメンバに追加. ゲッタとセッタも追加. 
`motion_t`のサブクラスは`get_body_force`で体積力を参照する.
後方互換性のため, オプション引数にしている. `droplet_motion_t`はデフォルトで`[0, 0, -9.8]`になっている. 