### PR TITLE
simulator non-dimensionalized

### DIFF
--- a/PyPTS/field.py
+++ b/PyPTS/field.py
@@ -10,15 +10,53 @@ _pypts._pypts_flib.init_field_afdet.argtypes = [ctypes.c_char_p]
 _pypts._pypts_flib.init_field_afdet.restype = None
 
 def init_field_vtk(filename:str, read_ascii:bool):
+    """
+    Initializes the flow field. 
 
+    The flow field is constructed from grid data stored in Legacy VTK unstructured grid format (.vtk). 
+    If the grid data also contains field data such as velocity and temperature fields, they are restored as well. 
+
+    Parameters
+    -----------
+    filename (str) : filename in which the grid data is stored.
+    read_ascii (bool) : read the file in ASCII format.
+
+    Note
+    ------
+    The name of the field data stored in the flow field must be `velocity` for velocity and `temperature` for temperature. 
+    Currently, no method is provided to restore a flow variable by specifying the field name for the variable. 
+
+    Note that all input parameters must be non-dimensionalized by the corresponding representative parameters. 
+    PyPTS has no way to determine if the dimensions of these parameters are appropriate. 
+    The user is solely responsible for the adequacy of the parameters specified. 
+
+    """
     b_filename = filename.encode()
+    if not read_ascii:
+        raise NotImplementedError("read_binary is not implemented.")
+    
     _pypts._pypts_flib.init_field_vtk(b_filename,
                                       ctypes.byref(ctypes.c_bool(read_ascii)))
 
     _pypts.logger.info("field data succesfully initialized from {0}".format(filename))
 
 def init_field_afdet(filename:str):
+    """
+    Initializes the flow field. 
 
+    The flow field is constructed from grid data stored in afdet solver format (.bin). 
+    If the grid data also contains field data such as velocity and temperature fields, they are restored as well. 
+
+    Parameters
+    -----------
+    filename (str) : filename in which the grid data is stored.
+
+    Note
+    ------
+    Note that all input parameters must be non-dimensionalized by the corresponding representative parameters. 
+    PyPTS has no way to determine if the dimensions of these parameters are appropriate. 
+    The user is solely responsible for the adequacy of the parameters specified. 
+    """
     b_filename = filename.encode()
     _pypts._pypts_flib.init_field_afdet(b_filename)
 

--- a/PyPTS/motions.f90
+++ b/PyPTS/motions.f90
@@ -7,19 +7,17 @@ module motions_m
     
 contains
 
-subroutine assign_droplet_motion(dt, L_ref, U_ref, rho_f, mu_f, rho_p, RK_order, body_force) bind(c, name="assign_droplet_motion")
+subroutine assign_droplet_motion(dt, Re, rho_f, rho_p, RK_order, body_force) bind(c, name="assign_droplet_motion")
     real(c_double),intent(in) :: dt
-    real(c_double),intent(in) :: L_ref
-    real(c_double),intent(in) :: U_ref
+    real(c_double),intent(in) :: Re
     real(c_double),intent(in) :: rho_f
-    real(c_double),intent(in) :: mu_f
     real(c_double),intent(in) :: rho_p
     integer(c_int),intent(in) :: RK_order
     real(c_double),intent(in) :: body_force(3)
 
     type(droplet_motion_t) motion_
 
-    call motion_%construct_droplet_motion(dt, L_ref, U_ref, rho_f, mu_f, rho_p, RK_order, body_force)
+    call motion_%construct_droplet_motion(dt, Re, rho_f, rho_p, RK_order, body_force)
 
     call mv_simulator%set_motion(motion_)
 

--- a/PyPTS/motions.py
+++ b/PyPTS/motions.py
@@ -7,25 +7,40 @@ _pypts._pypts_flib.assign_droplet_motion.argtypes = [
                                          ctypes.POINTER(ctypes.c_double),
                                          ctypes.POINTER(ctypes.c_double),
                                          ctypes.POINTER(ctypes.c_double),
-                                         ctypes.POINTER(ctypes.c_double),
-                                         ctypes.POINTER(ctypes.c_double),
                                          ctypes.POINTER(ctypes.c_int),
                                          np.ctypeslib.ndpointer(dtype=np.float64)]
 _pypts._pypts_flib.assign_droplet_motion.restype = None
 
 
 
-def droplet(dt:float, L_ref:float, U_ref:float, rho_f:float, mu_f:float, rho_p:float, RK_order:int,
-            gravity:list=[0.0, 0.0, -9.806]) -> None:
+def droplet(dt:float, Re:float, rho_f:float, rho_p:float, RK_order:int,
+            gravity) -> None:
     """
-    droplet motion. 
+    droplet motion. Particles are considered as uniform spheres of radius r and density `rho_p`, 
+    and they move in a fluid of density `rho_f`. 
+    Particles are subjected to gravity and hydrodynamic drag force from the fluid. The magnitude of the drag force is a function of the Reynolds number, 
+    which is determined by the Reynolds number of the flow field `Re` and the velocity of the particle. 
+    The motion of particles is discretized and integrated by the k-step low-storage Runge-Kutta method. 
+
+    Note
+    ------
+    Note that all input parameters must be non-dimensionalized by the corresponding representative parameters. 
+    PyPTS has no way to determine if the dimensions of these parameters are appropriate. 
+    The user is solely responsible for the adequacy of the parameters specified. 
+    
+    Parameters
+    -----------
+    dt (float) : time stepping size [LU^-1]
+    Re (float) : Reynolds number
+    rho_f (float) : density of fluid [ρ]
+    rho_p (float) : density of particle [ρ]
+    RK_order (int) : order of the Runge-Kutta scheme
+    gravity (list[float]) : gravity force exerted on a particle. 
     """
     _pypts._pypts_flib.assign_droplet_motion(
                                  ctypes.byref(ctypes.c_double(dt)),
-                                 ctypes.byref(ctypes.c_double(L_ref)),
-                                 ctypes.byref(ctypes.c_double(U_ref)),
+                                 ctypes.byref(ctypes.c_double(Re)),
                                  ctypes.byref(ctypes.c_double(rho_f)),
-                                 ctypes.byref(ctypes.c_double(mu_f)),
                                  ctypes.byref(ctypes.c_double(rho_p)),
                                  ctypes.byref(ctypes.c_int(RK_order)),
                                  np.array(gravity, dtype=np.float64))

--- a/PyPTS/simulation.py
+++ b/PyPTS/simulation.py
@@ -1,6 +1,7 @@
 import numpy as np
 import ctypes
 from . import _pypts
+import signal
 
 # init
 _pypts._pypts_flib.initialize_simulation.argtypes = [ctypes.POINTER(ctypes.c_int),
@@ -48,6 +49,7 @@ def initialize(nwrite:int, write_ascii:bool, traj_path:str,
                                              )
     
 def run(nstart:int, nend:int):
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
     _pypts._pypts_flib.run_simulation(ctypes.byref(ctypes.c_int(nstart)),
                                       ctypes.byref(ctypes.c_int(nend)),
                                      )

--- a/lib/Version.f90
+++ b/lib/Version.f90
@@ -2,8 +2,8 @@ module version_m
     !! treat version of this project
     implicit none
     integer,parameter,private :: MAJOR_VERSION = 0
-    integer,parameter,private :: MINOR_VERSION = 1
-    integer,parameter,private :: PATCH_VERSION = 2
+    integer,parameter,private :: MINOR_VERSION = 2
+    integer,parameter,private :: PATCH_VERSION = 0
 
     public :: get_version
 

--- a/sample/free_fall/Makefile
+++ b/sample/free_fall/Makefile
@@ -1,7 +1,7 @@
 FC = gfortran
 TARGET = main
 SRC = main.f90
-FFLAGS := -O0 -fopenmp -fbacktrace -fcheck=all
+FFLAGS := -O0 -fbacktrace -fcheck=all
 
 #モジュールファイルの出力場所
 MODDIR = ./mod

--- a/sample/python/testrun.py
+++ b/sample/python/testrun.py
@@ -24,14 +24,17 @@ field.init_field_vtk("../sax_flow/sax_flow.vtk", True)
 
 
 # motion
-n_rk = 4
-rho_p = 1000.0
-mu_p  = 0.001
-rho_f = 1.0
-mu_f  = 1e-5
-dt = 0.0001
 L = U = 1.0
-motions.droplet(dt, L, U, rho_f, mu_f, rho_p, n_rk)
+RHO = 1.0
+n_rk = 4
+rho_p = 1000.0/RHO
+rho_f = 1.0/RHO
+MU  = 1e-5
+Re = RHO*U*L/MU
+dt = 0.0001/(L/U)
+g = np.array([0,0,-9.81])
+g /= (U*U/L)
+motions.droplet(dt, Re, rho_f, rho_p, n_rk, g)
 
 # updater is disabled (i.e. steady flow)
 update.no_update()

--- a/sample/sax_flow/main.f90
+++ b/sample/sax_flow/main.f90
@@ -58,16 +58,19 @@ program main
     end block
 
     block
+        real(8),parameter :: L = 1.0d0
+        real(8),parameter :: U = 1.0d0
+        real(8),parameter :: RHO = 1.0d0
+        real(8),parameter :: MU = 1d-5
+        real(8),parameter :: Re = RHO*U*L/MU
+        
         integer,parameter :: n_rk = 4
-        real(8),parameter :: rho_p = 1000.d0
-        real(8),parameter :: mu_p  = 1d-3
-        real(8),parameter :: rho_f = 1.d0
-        real(8),parameter :: mu_f  = 1d-5
-        real(8),parameter :: dt = 0.001
-        real(8),parameter :: Lref = 1.0d0
-        real(8),parameter :: Uref = 1.0d0
+        real(8),parameter :: rho_p = 1000.d0/RHO
+        real(8),parameter :: rho_f = 1.d0/RHO
+        real(8),parameter :: dt = 0.001/(L/U)
+        real(8),parameter :: g(3) = [0.0, 0.0, -9.81]/(U*U/L)
 
-        call motion%construct_droplet_motion(dt, Lref, Uref, rho_f, mu_f, rho_p, n_rk)
+        call motion%construct_droplet_motion(dt, Re, rho_f, rho_p, n_rk, g)
     end block
 
     call mv_field_updater%disable_updater()


### PR DESCRIPTION
#21 のため, `motion_t`から代表長さと代表速度, 代表密度および代表粘度をコンストラクタとメンバ変数から削除. 
今後はシミュレータに与えるパラメータは無次元化されると前提をおく. 