### PR TITLE
modified path specification in simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *main*
 !main.f90
 *.DS_Store
+*.dat

--- a/PyPTS/simulation.py
+++ b/PyPTS/simulation.py
@@ -2,6 +2,7 @@ import numpy as np
 import ctypes
 from . import _pypts
 import signal
+import os
 
 # init
 _pypts._pypts_flib.initialize_simulation.argtypes = [ctypes.POINTER(ctypes.c_int),
@@ -38,8 +39,35 @@ _pypts._pypts_flib.set_dump_settings.restype = None
 
 
 
-def initialize(nwrite:int, write_ascii:bool, traj_path:str, 
-               nback:int, backup_ascii:bool, backup_path:str):
+def initialize(nwrite:int, write_ascii:bool, traj_dir:str, 
+               nback:int, backup_ascii:bool, backup_dir:str):
+    """
+    Initialize the simulation. 
+
+    When initializing the simulation, the flow field, particle data, motion objects, and updaters 
+    do not necessarily have to be initialized. 
+
+    The particle data at each time are stored in two independent files: trajectory and backup. 
+
+    The trajectory file (.vtk) is a Legacy VTK format file and is mainly used for visualization. 
+    The position and state of a particle at each time are stored at each independent time step. 
+    The user can control the time step interval at which the trajectory files are saved and the directory in which the files are saved. 
+    The name of the saved file is `traj_path/trajectory__####.vtk`, 
+    where `traj_path` is the path where the trajectory file is saved and #### is the time step where the data was recorded.
+
+    The backup file (.pdata) contains all the data of the particles at each time step. 
+    
+    Parameters
+    -----------
+    nwrite (int) : Time step interval at which the particle trajectory visualization files (.vtk) will be output.
+    write_ascii (bool) : Save trajectory files in ASCII.
+    traj_dir (str) : Path of the directory where  trajectory files are stored. 
+    nback (int)  : Time step interval at which the particle trajectory backup data (.pdata) will be output.
+    backup_ascii (bool) : Save backupdata in ASCII.
+    backup_dir (str) : Path of the directory where backup data ais stored. 
+    """
+    traj_path = os.path.join(traj_dir, "trajectory")
+    backup_path = os.path.join(backup_dir, "particle")
     _pypts._pypts_flib.initialize_simulation(ctypes.byref(ctypes.c_int(nwrite)),
                                              ctypes.byref(ctypes.c_bool(write_ascii)),
                                              traj_path.encode(),
@@ -49,6 +77,12 @@ def initialize(nwrite:int, write_ascii:bool, traj_path:str,
                                              )
     
 def run(nstart:int, nend:int):
+    """
+    Runs the simulation for the specified timesteps between `nstart` and `nend`. 
+
+    At the time of execution, all the necessary data for the simulation (particle data, flow field data, updater, and motion) 
+    must be prepared. 
+    """
     signal.signal(signal.SIGINT, signal.SIG_DFL)
     _pypts._pypts_flib.run_simulation(ctypes.byref(ctypes.c_int(nstart)),
                                       ctypes.byref(ctypes.c_int(nend)),

--- a/lib/Simulator.f90
+++ b/lib/Simulator.f90
@@ -85,7 +85,7 @@ subroutine set_writeout_settings(this, nwrite, write_ascii, path_write)
     
     this%nwrite_ = nwrite
     this%write_ascii_ = write_ascii
-    this%basename_vtk_ = path_write//"/"//"trajectory"
+    this%basename_vtk_ = path_write !//"/"//"trajectory"
 
 end subroutine
 
@@ -98,7 +98,7 @@ subroutine set_dump_settings(this, nback, backup_ascii, path_back)
     
     this%nback_  = nback
     this%backup_ascii_ = backup_ascii
-    this%basename_back_ = path_back//"/"//"backup"
+    this%basename_back_ = path_back !//"/"//"backup"
 
 end subroutine
 

--- a/sample/sax_flow/main.f90
+++ b/sample/sax_flow/main.f90
@@ -75,7 +75,7 @@ program main
 
     call mv_field_updater%disable_updater()
 
-    call mv_simulator%construct_simulator(10000, write_ascii, "./data", 10000, .false., "./data")
+    call mv_simulator%construct_simulator(10000, write_ascii, "./data/trajectory", 10000, .false., "./data/backup")
     call mv_simulator%set_motion(motion)
     call mv_simulator%run(1, 100000)
 


### PR DESCRIPTION
OSごとにパスのセパレータが異なるので, simulatorの初期化時にわたすトラジェクトリファイルとパックアップファイルのパス`write_path`, `back_path`をファイルのベース名まで指定するように変更. 