### PR TITLE
use move_alloc in update_flow_field

### DIFF
--- a/lib/FieldUpdater.f90
+++ b/lib/FieldUpdater.f90
@@ -155,12 +155,12 @@ pure integer function get_current_step(this)
     !! get current timestep of flow field
     class(field_updater_t),intent(in) :: this
 
-    get_current_step = this%interval_*this%interval_
+    get_current_step = this%counter_*this%interval_
 
 end function
 
 pure function get_current_filename(this) result(fname)
-    !! get current timestep of flow field
+    !! get current filename of flow field
     class(field_updater_t),intent(in) :: this
 
     character(128) fname


### PR DESCRIPTION
パフォーマンス重視のため, ugridからflow_fieldへ変数を移動するときに`move_alloc`を使う. 
allocateに比べて, 一時コピーがなくなり, コピー自体も速いはずなので優れている. 