### PR TITLE
refactoring around half_faces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/mod)
 add_subdirectory(lib)
 
 # for Python interface
-add_subdirectory(PyPTS)
+# add_subdirectory(PyPTS)
 
 # test
 enable_testing()

--- a/PyPTS/field.f90
+++ b/PyPTS/field.f90
@@ -2,13 +2,21 @@ module init_m
     use iso_c_binding
     use util_m
     use kind_parameters_m
-    use base_importer_m
     use vtk_importer_m
     use afdet_importer_m
     use flow_field_m
     implicit none
     
 contains
+
+subroutine init_field(ugrid)
+    !! initialize a flow field and delete ugrid.
+    type(ugrid_struct_t),intent(inout) :: ugrid
+
+    call construct_flow_field(ugrid)
+    call delete_ugrid(ugrid)
+
+end subroutine
 
 subroutine init_field_vtk(c_filename, ascii) bind(c, name="init_field_vtk")
     character(c_char),dimension(*),intent(in) :: c_filename
@@ -32,9 +40,7 @@ subroutine init_field_vtk(c_filename, ascii) bind(c, name="init_field_vtk")
     call vtk_importer_%read_file(ugrid_, .true.)
     call vtk_importer_%close()
 
-    call construct_flow_field(ugrid_, CELL_TYPE_VTK, FACE_VERT_DEF_VTK)
-
-    call delete_ugrid(ugrid_)
+    call init_field(ugrid_)
 
 end subroutine
 
@@ -59,10 +65,9 @@ subroutine init_field_afdet(c_filename) bind(c, name="init_field_afdet")
     call importer_%open_file(filename)
     call importer_%read_file(ugrid_, .false.)
     call importer_%close()
-
-    call construct_flow_field(ugrid_, CELL_TYPE_DEF_AFDET, FACE_VERT_DEF_VTK)
-    call delete_ugrid(ugrid_)
     
+    call init_field(ugrid_)
+
 end subroutine
 
 end module

--- a/PyPTS/update.f90
+++ b/PyPTS/update.f90
@@ -29,7 +29,7 @@ subroutine update_field_vtk(dt_f, dt_p, basename, pad, field_only, verts_only, i
         call vtk_importer%open_ascii_off()
     end if
 
-    call mv_field_updater%construct_field_updater(vtk_importer, CELL_TYPE_VTK, FACE_VERT_DEF_VTK, &
+    call mv_field_updater%construct_field_updater(vtk_importer, &
     dt_f, dt_p, fstring(basename), pad, ".vtk", logical(field_only), logical(verts_only), interval)
 
 end subroutine

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,14 +4,14 @@ add_library(partras STATIC
     DropletMotion.f90
     DropletMotionLegacy.f90
     DumpFile.f90
-    FieldUpdater.f90
+#    FieldUpdater.f90
     Geometry.f90
     Idlist.f90
     KindParameters.f90
     Motion.f90
     FlowField.f90
     ParticleData.f90
-    Simulator.f90
+#    Simulator.f90
     UnstructuredMesh.f90
     VTKImporter.f90
     Version.f90

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,14 +4,14 @@ add_library(partras STATIC
     DropletMotion.f90
     DropletMotionLegacy.f90
     DumpFile.f90
-#    FieldUpdater.f90
+    FieldUpdater.f90
     Geometry.f90
     Idlist.f90
     KindParameters.f90
     Motion.f90
     FlowField.f90
     ParticleData.f90
-#    Simulator.f90
+    Simulator.f90
     UnstructuredMesh.f90
     VTKImporter.f90
     Version.f90

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(partras STATIC
     ParticleData.f90
     Simulator.f90
     UnstructuredMesh.f90
+    ValidationMethods.f90
     VTKImporter.f90
     Version.f90
 )

--- a/lib/FieldUpdater.f90
+++ b/lib/FieldUpdater.f90
@@ -2,6 +2,7 @@ module field_updater_m
     use kind_parameters_m
     use flow_field_m
     use base_importer_m
+    use unstructured_mesh_m
     implicit none
     private
 
@@ -12,10 +13,6 @@ module field_updater_m
         private
         class(ugrid_importer_t),allocatable :: importer_
             !! importer
-        type(cell_type_t) :: ct_
-            !! cell type definitions
-        type(face_vertex_def_t) :: fv_def_
-            !! face-vertex connectivity definition
         real(DP) :: dt_flow_
             !! time stepping size in flow field
         real(DP) :: dt_part_
@@ -59,16 +56,12 @@ logical function assigned(this)
 
 end function
 
-subroutine construct_field_updater(this, importer, cell_type_def, face_vert_def, dt_f, dt_p, &
+subroutine construct_field_updater(this, importer, dt_f, dt_p, &
                                    basename, pad, ext, field_only, verts_only, interval)
     !! create field_updater object
     class(field_updater_t),intent(inout) :: this
     class(ugrid_importer_t),intent(in) :: importer
         !! importer used in this updater
-    type(cell_type_t),intent(in) :: cell_type_def
-        !! cell type definitions for importer
-    type(face_vertex_def_t),intent(in) :: face_vert_def
-        !! face-vertex connectivity definitions for importer
     real(DP),intent(in) :: dt_f
         !! time stepping size for fluid flow
     real(DP),intent(in) :: dt_p
@@ -87,8 +80,6 @@ subroutine construct_field_updater(this, importer, cell_type_def, face_vert_def,
         !! Output interval of flow field file
 
     allocate(this%importer_, source=importer)
-    this%ct_ = cell_type_def
-    this%fv_def_ = face_vert_def
 
     this%dt_flow_ = dt_f
     this%dt_part_ = dt_p
@@ -141,7 +132,7 @@ subroutine update_field(this, ncyc)
 
         call this%importer_%read_file(ugrid_, .true.)
         
-        call update_flow_field(ugrid_, this%ct_, this%fv_def_, this%field_only_, this%verts_only_)
+        call update_flow_field(ugrid_, this%field_only_, this%verts_only_)
     
         call this%importer_%close()
 

--- a/lib/FlowField.f90
+++ b/lib/FlowField.f90
@@ -1,7 +1,6 @@
 module flow_field_m
     !! treat 3d unstructured flow field.
     use kind_parameters_m
-    use base_importer_m, only : ugrid_struct_t, cell_type_t, face_vertex_def_t !, FIELD_NAME_LEN
     use unstructured_mesh_m
     use geometry_m
     implicit none
@@ -38,6 +37,8 @@ module flow_field_m
     type(flow_field_t),protected :: mv_flow_field
         !! flow field object (module variable)
 
+    type(half_face_t),allocatable :: mv_half_faces_(:)
+
     public mv_flow_field, &
            construct_flow_field, &
            update_flow_field, &
@@ -48,17 +49,13 @@ module flow_field_m
 
 contains
 
-subroutine construct_flow_field(ugrid, cell_type_def, face_vert_def)
+subroutine construct_flow_field(ugrid)
     type(ugrid_struct_t),intent(inout) :: ugrid
         !! unstructured grid importer
-    type(cell_type_t),intent(in) :: cell_type_def
-        !! cell type definition
-    type(face_vertex_def_t),intent(in) :: face_vert_def
-        !! face-vertex connectivity definition
 
     ! これを呼び出す際はフィールド変数はすべて未割り付けと仮定. 
     ! すでに割り付けしているのにこれを呼び出した場合: 一旦delete処理が入るので普通に動く. 
-    call update_flow_field(ugrid, cell_type_def, face_vert_def, .false., .false.)
+    call update_flow_field(ugrid, .false., .false.)
 
 end subroutine
 
@@ -105,7 +102,9 @@ subroutine update_members_(ugrid, field_only, verts_only)
                 call move_alloc(ugrid%face2cells, mv_flow_field%face2cells)
                 call move_alloc(ugrid%face2verts, mv_flow_field%face2verts)
             else
-                call create_faces(mv_flow_field%face2cells, mv_flow_field%face2verts)
+                call construct_half_faces(ugrid, mv_half_faces_)
+                call create_faces(mv_half_faces_, mv_flow_field%face2cells, mv_flow_field%face2verts)
+                deallocate(mv_half_faces_)
             end if
 
             call create_boundary_faces(mv_flow_field%face2cells, mv_flow_field%boundary_faces)
@@ -151,28 +150,16 @@ subroutine update_members_(ugrid, field_only, verts_only)
 
 end subroutine
 
-subroutine update_flow_field(ugrid, cell_type_def, face_vert_def, field_only, verts_only)
+subroutine update_flow_field(ugrid, field_only, verts_only)
     !! update flow field. 
     type(ugrid_struct_t),intent(inout) :: ugrid
         !! unstructured grid importer
-    type(cell_type_t),intent(in) :: cell_type_def
-        !! cell type definition
-    type(face_vertex_def_t),intent(in) :: face_vert_def
-        !! face-vertex connectivity definition
     logical,intent(in) :: field_only
     logical,intent(in) :: verts_only
-
-
-    !NOTE: メッシュがポリへドラルの場合, そもそもhalf_facesが構築できない. その場合half_faceの構築はskipするしかない. 
-    !      したがって, ポリへドラルメッシュの場合面ーセル関係がugridで全て構築済みでなければならない. 
-    if ( .not. field_only .and. .not. verts_only) call construct_half_faces(ugrid, cell_type_def, face_vert_def)
 
     call update_members_(ugrid, field_only, verts_only)
 
     call validate_flow_field()
-
-    ! delete current data of half faces
-    call delete_half_faces()
     
     mv_flow_field%is_assigned = .true.
 

--- a/lib/FlowField.f90
+++ b/lib/FlowField.f90
@@ -320,6 +320,7 @@ subroutine delete_mesh_field()
     if (allocated(mv_flow_field%cell_centers)) deallocate(mv_flow_field%cell_centers)
     if (allocated(mv_flow_field%boundary_faces)) deallocate(mv_flow_field%boundary_faces)
     if (allocated(mv_flow_field%velocity)) deallocate(mv_flow_field%velocity)
+    if (allocated(mv_flow_field%temperature)) deallocate(mv_flow_field%temperature)
     if (allocated(mv_flow_field%verts)) deallocate(mv_flow_field%verts)
 
     mv_flow_field%ncell = 0

--- a/lib/UnstructuredMesh.f90
+++ b/lib/UnstructuredMesh.f90
@@ -23,7 +23,9 @@ module unstructured_mesh_m
         integer(IP),allocatable :: offsets(:)
         integer(IP),allocatable :: cell2verts(:,:)
         integer(IP),allocatable :: cell_types(:)
+
         real(DP),allocatable :: cell_velocity(:,:)
+        real(DP),allocatable :: cell_temperature(:)
 
         ! CFDデータのサポート. 
         ! 特定のCFDデータは面ーセル接続関係をファイルに書き込む場合がある. 

--- a/lib/UnstructuredMesh.f90
+++ b/lib/UnstructuredMesh.f90
@@ -495,12 +495,15 @@ module unstructured_mesh_m
         if (allocated(this%conns))        deallocate(this%conns)
         if (allocated(this%offsets))      deallocate(this%offsets)
         if (allocated(this%cell_types))   deallocate(this%cell_types)
+        if (allocated(this%cell2verts))   deallocate(this%cell2verts)
         if (allocated(this%cell_velocity))deallocate(this%cell_velocity)
-    
+        if (allocated(this%cell_temperature)) deallocate(this%cell_temperature)
+        
         ! this%filename = FILENAME_NOT_ASSIGNED
         if ( allocated(this%face2cells) ) deallocate(this%face2cells) 
         if ( allocated(this%face2verts) ) deallocate(this%face2verts) 
         if ( allocated(this%face_centers) ) deallocate(this%face_centers) 
+        if ( allocated(this%face_normals) ) deallocate(this%face_normals) 
         if ( allocated(this%cell_centers) ) deallocate(this%cell_centers) 
     end subroutine
     

--- a/lib/VTKImporter.f90
+++ b/lib/VTKImporter.f90
@@ -1,54 +1,17 @@
 module vtk_importer_m
     use kind_parameters_m
+    use unstructured_mesh_m
     use base_importer_m
     use id_list_m
     implicit none
-    private
-    integer,parameter,private :: VTK_TETRA = 10
-    integer,parameter,private :: VTK_WEDGE = 13
-    integer,parameter,private :: VTK_HEXA  = 12
-    integer,parameter,private :: VTK_PYRAMID = 14
-
-    integer,parameter :: face_def_tetra(4,4) = reshape([[3, 1,3,2], &
-                                                        [3, 1,2,4], &
-                                                        [3, 2,3,4], &
-                                                        [3, 3,1,4]], shape=shape(face_def_tetra))
-
-    integer,parameter :: face_def_wedge(5,5) = reshape([[3, 1,3,2,-1], &
-                                                        [3, 4,5,6,-1], &
-                                                        [4, 1,2,5,4], &
-                                                        [4, 2,3,6,5], &
-                                                        [4, 1,4,6,3]], shape=shape(face_def_wedge))
-
-    integer,parameter :: face_def_hexa(5,6) = reshape([[4, 2,1,4,3], &
-                                                       [4, 1,5,8,4], &
-                                                       [4, 5,6,7,8], &
-                                                       [4, 2,3,7,6], &
-                                                       [4, 2,6,5,1], &
-                                                       [4, 3,4,8,7]], shape=shape(face_def_hexa))
-
-    integer,parameter :: face_def_pyram(5,5) = reshape([[3, 5,1,2,-1], &
-                                                        [3, 5,2,3,-1], &
-                                                        [3, 5,3,4,-1], &
-                                                        [3, 5,4,1,-1], &
-                                                        [4, 1,4,3,2]], shape=shape(face_def_pyram)) 
-
-    type(cell_type_t),parameter :: CELL_TYPE_VTK = cell_type_t(VTK_TETRA, VTK_WEDGE, VTK_HEXA, VTK_PYRAMID)
-        !! cell type definition for VTK (module variable)
-    type(face_vertex_def_t),parameter :: FACE_VERT_DEF_VTK = face_vertex_def_t(face_def_tetra, &
-                                                                               face_def_wedge, &
-                                                                               face_def_hexa, &
-                                                                               face_def_pyram)
-        !! face-vertex connectivity definition for VTK (module variable)
-    
+    private    
     type,extends(ugrid_importer_t) :: vtk_importer_t
 
         contains
         procedure :: read_file => import_vtk_ugrid_legacy
     end type
 
-    public vtk_importer_t, &
-           CELL_TYPE_VTK, FACE_VERT_DEF_VTK
+    public vtk_importer_t
 
 contains
 

--- a/lib/ValidationMethods.f90
+++ b/lib/ValidationMethods.f90
@@ -1,0 +1,69 @@
+module validation_methods_m
+    use kind_parameters_m
+    implicit none
+    private
+    interface validate_array
+        module procedure validate_int_array
+        module procedure validate_real_array
+    end interface
+
+    interface validate_array_strict
+        module procedure validate_int_array_strict
+        module procedure validate_real_array_strict
+    end interface
+
+    public :: validate_array, validate_array_strict
+
+    contains
+
+logical function validate_real_array(arr, arr_shape) result(valid)
+    real(DP),allocatable,intent(in) :: arr(..)
+    integer(IP),intent(in) :: arr_shape(rank(arr))
+
+    valid = .true.
+    if ( all(shape(arr) /= arr_shape) ) then
+        valid = .false.
+    end if
+
+end function
+
+logical function validate_int_array(arr, arr_shape) result(valid)
+    integer(IP),allocatable,intent(in) :: arr(..)
+    integer(IP),intent(in) :: arr_shape(rank(arr))
+
+    valid = .true.
+    if ( all(shape(arr) /= arr_shape) ) then
+        valid = .false.
+    end if
+
+end function
+
+!==========================================
+
+logical function validate_real_array_strict(arr, arr_shape) result(valid)
+    real(DP),allocatable,intent(in) :: arr(..)
+    integer(IP),intent(in) :: arr_shape(rank(arr))
+
+    valid = .true.
+    if ( .not. allocated(arr) ) then
+        valid = .false.
+    else
+        valid = validate_real_array(arr, arr_shape)
+    end if
+
+end function
+
+logical function validate_int_array_strict(arr, arr_shape) result(valid)
+    integer(IP),allocatable,intent(in) :: arr(..)
+    integer(IP),intent(in) :: arr_shape(rank(arr))
+
+    valid = .true.
+    if ( .not. allocated(arr) ) then
+        valid = .false.
+    else
+        valid = validate_int_array(arr, arr_shape)
+    end if
+
+end function
+    
+end module validation_methods_m

--- a/sample/free_fall/main.f90
+++ b/sample/free_fall/main.f90
@@ -1,5 +1,5 @@
 program main
-    use base_importer_m, only: ugrid_struct_t, delete_ugrid
+    use unstructured_mesh_m
     use vtk_importer_m
     use flow_field_m
     use particle_data_m
@@ -32,7 +32,7 @@ program main
     call vtk_importer%open_ascii_on()
     call vtk_importer%open_file("quiescent.vtk")
     call vtk_importer%read_file(vtk_ugrid, shift_index=.true.)
-    call construct_flow_field(vtk_ugrid, CELL_TYPE_VTK, FACE_VERT_DEF_VTK)
+    call construct_flow_field(vtk_ugrid)
     call delete_ugrid(vtk_ugrid)
 
     call construct_particle_data(200)

--- a/sample/free_fall_compare/main.f90
+++ b/sample/free_fall_compare/main.f90
@@ -1,5 +1,5 @@
 program main
-    use base_importer_m, only: ugrid_struct_t, delete_ugrid
+    use unstructured_mesh_m
     use vtk_importer_m
     use flow_field_m
     use particle_data_m
@@ -40,7 +40,7 @@ program main
     call vtk_importer%open_ascii_on()
     call vtk_importer%open_file("../free_fall/quiescent.vtk")
     call vtk_importer%read_file(vtk_ugrid, shift_index=.true.)
-    call construct_flow_field(vtk_ugrid, CELL_TYPE_VTK, FACE_VERT_DEF_VTK)
+    call construct_flow_field(vtk_ugrid)
     call delete_ugrid(vtk_ugrid)
 
 

--- a/sample/sax_flow/main.f90
+++ b/sample/sax_flow/main.f90
@@ -1,6 +1,6 @@
 program main
     use kind_parameters_m
-    use base_importer_m, only: ugrid_struct_t, delete_ugrid
+    use unstructured_mesh_m
     use vtk_importer_m
     use flow_field_m
     use particle_data_m
@@ -23,7 +23,7 @@ program main
 
     call vtk_importer%open_file("sax_flow.vtk")
     call vtk_importer%read_file(vtk_ugrid, .true.)
-    call construct_flow_field(vtk_ugrid, CELL_TYPE_VTK, FACE_VERT_DEF_VTK)
+    call construct_flow_field(vtk_ugrid)
     call vtk_importer%close()
     call delete_ugrid(vtk_ugrid)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,7 +37,7 @@ ADDTEST(mesh_field_vtk)
 ADDTEST(vtk_importer)
 ADDTEST(afdet_importer)
 ADDTEST(refcell_search)
-# ADDTEST(field_updater)
+ADDTEST(field_updater)
 
 if(OpenMP_Fortran_FOUND)
     ADDTEST(refcell_search_parallel)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,7 +37,7 @@ ADDTEST(mesh_field_vtk)
 ADDTEST(vtk_importer)
 ADDTEST(afdet_importer)
 ADDTEST(refcell_search)
-ADDTEST(field_updater)
+# ADDTEST(field_updater)
 
 if(OpenMP_Fortran_FOUND)
     ADDTEST(refcell_search_parallel)

--- a/test/test_afdet_importer.f90
+++ b/test/test_afdet_importer.f90
@@ -1,6 +1,5 @@
 program test_afdet_impoter
-    use base_importer_m, only: ugrid_struct_t
-    use vtk_importer_m, only: FACE_VERT_DEF_VTK
+    use unstructured_mesh_m
     use afdet_importer_m
     use flow_field_m
     implicit none
@@ -19,6 +18,6 @@ program test_afdet_impoter
     end if
 
     !読み込めるかのテスト
-    call construct_flow_field(grid, CELL_TYPE_DEF_AFDET, FACE_VERT_DEF_VTK)
+    call construct_flow_field(grid)
 
 end program 

--- a/test/test_field_updater.f90
+++ b/test/test_field_updater.f90
@@ -1,6 +1,6 @@
 program test_field_updater
     use kind_parameters_m
-    use base_importer_m, only: ugrid_struct_t
+    use unstructured_mesh_m
     use flow_field_m
     use vtk_importer_m
     use field_updater_m
@@ -17,14 +17,14 @@ program test_field_updater
     call vtk_importer%read_file(vtk_ugrid, shift_index=.true.)
     call vtk_importer%close()
 
-    call construct_flow_field(vtk_ugrid, CELL_TYPE_VTK, FACE_VERT_DEF_VTK)
+    call construct_flow_field(vtk_ugrid)
 
     call importer%open_ascii_on()
     call importer%open_stream_on()
 
     dt_f = 0.01
     dt_p = 0.01
-    call mv_field_updater%construct_field_updater(importer, CELL_TYPE_VTK, FACE_VERT_DEF_VTK, & 
+    call mv_field_updater%construct_field_updater(importer, & 
                                                   dt_f, dt_p, &
                                                   "flow_", 0, ".vtk", .true., .true., 1)
 

--- a/test/test_mesh_field.f90
+++ b/test/test_mesh_field.f90
@@ -1,6 +1,5 @@
 program test
-    use vtk_importer_m, only : CELL_TYPE_VTK, FACE_VERT_DEF_VTK
-    use base_importer_m, only : ugrid_struct_t
+    use unstructured_mesh_m
     use flow_field_m
     implicit none
     integer,parameter :: nvert = 12
@@ -71,7 +70,7 @@ program test
     ugrid%verts = verts
     ugrid%cell_velocity = vv
         
-    call construct_flow_field(ugrid, CELL_TYPE_VTK, FACE_VERT_DEF_VTK)
+    call construct_flow_field(ugrid)
     
     if ( mv_flow_field%ncell /= 2 ) then
         error stop "ncell"

--- a/test/test_mesh_field_vtk.f90
+++ b/test/test_mesh_field_vtk.f90
@@ -1,6 +1,6 @@
 program test
-    use base_importer_m, only: ugrid_struct_t, delete_ugrid
     use vtk_importer_m
+    use unstructured_mesh_m
     use flow_field_m
     implicit none
     integer i
@@ -16,8 +16,7 @@ program test
 
     allocate(v(3,vtk_ugrid%ncell), source=0.d0)
     vtk_ugrid%cell_velocity = v
-    call construct_flow_field(vtk_ugrid, &
-                              CELL_TYPE_VTK, FACE_VERT_DEF_VTK)
+    call construct_flow_field(vtk_ugrid)
 
     call delete_ugrid(vtk_ugrid)
 

--- a/test/test_refcell_search.f90
+++ b/test/test_refcell_search.f90
@@ -1,5 +1,5 @@
 program test
-    use base_importer_m, only: ugrid_struct_t, delete_ugrid
+    use unstructured_mesh_m
     use vtk_importer_m
     use flow_field_m
     implicit none
@@ -28,7 +28,7 @@ program test
 
     allocate(v(3,vtk_ugrid%ncell), source=0.d0)
     vtk_ugrid%cell_velocity = v
-    call construct_flow_field(vtk_ugrid, CELL_TYPE_VTK, FACE_VERT_DEF_VTK)
+    call construct_flow_field(vtk_ugrid)
     call delete_ugrid(vtk_ugrid)
 
     do i = 1, nsample

--- a/test/test_umesh.f90
+++ b/test/test_umesh.f90
@@ -1,5 +1,4 @@
 program test
-    use vtk_importer_m, only : CELL_TYPE_VTK, FACE_VERT_DEF_VTK
     use unstructured_mesh_m
     implicit none
     integer,parameter :: nvert = 12
@@ -9,14 +8,23 @@ program test
     integer,parameter :: cell_types(2)     = [12, 12]
     integer,allocatable :: face2cells(:,:), face2verts(:,:), boundary_faces(:), cell_offsets(:), cell_faces(:)
     integer i
-    call construct_half_faces(ncell, nvert, connectivity, offset, cell_types, CELL_TYPE_VTK, FACE_VERT_DEF_VTK)
+    type(half_face_t),allocatable :: half_faces(:)
+    type(ugrid_struct_t) ugrid
+
+    ugrid%ncell = ncell
+    ugrid%nvert = nvert
+    ugrid%conns = connectivity
+    ugrid%offsets = offset
+    ugrid%cell_types = cell_types
+
+    call construct_half_faces(ugrid, half_faces)
     print*, ""
     do i = 1, size(half_faces)
         print "('(owner, pair) = (', i0,1x,i0, ')')", half_faces(i)%owner-1, half_faces(i)%pair
         print "('verts = ', *(i0,:,',',1x), ']')", half_faces(i)%vertices(1:half_faces(i)%vert_count)-1
     end do
 
-    call create_faces(face2cells,face2verts)
+    call create_faces(half_faces, face2cells,face2verts)
 
     do i = 1, size(face2cells,dim=2)
         print*, face2cells(:,i)

--- a/test/test_umesh_vtk.f90
+++ b/test/test_umesh_vtk.f90
@@ -1,5 +1,4 @@
 program test
-    use base_importer_m, only: ugrid_struct_t
     use vtk_importer_m
     use unstructured_mesh_m
     implicit none
@@ -8,6 +7,7 @@ program test
     integer,allocatable :: cell_faces(:), cell_offsets(:)
     type(vtk_importer_t) vtk_importer
     type(ugrid_struct_t) vtk_ugrid
+    type(half_face_t),allocatable :: half_faces(:)
 
     call vtk_importer%open_ascii_on()
     call vtk_importer%open_stream_on()
@@ -15,8 +15,7 @@ program test
     call vtk_importer%read_file(vtk_ugrid, shift_index=.true.)
     call vtk_importer%close()
     
-    call construct_half_faces(vtk_ugrid%ncell, vtk_ugrid%nvert, vtk_ugrid%conns, vtk_ugrid%offsets, vtk_ugrid%cell_types, &
-                              CELL_TYPE_VTK, FACE_VERT_DEF_VTK)
+    call construct_half_faces(vtk_ugrid, half_faces)
     print*, ""
     do i = 1, size(half_faces)
         print "('face = ', i0)", i
@@ -24,7 +23,7 @@ program test
         print "('verts = ', *(i0,:,',',1x), ']')", half_faces(i)%vertices(1:half_faces(i)%vert_count)
     end do
 
-    call create_faces(face2cells,face2verts)
+    call create_faces(half_faces, face2cells,face2verts)
 
     do i = 1, size(face2cells,dim=2)
         print*, face2cells(:,i)

--- a/test/test_vtk_importer.f90
+++ b/test/test_vtk_importer.f90
@@ -1,5 +1,5 @@
 program test
-    use base_importer_m, only: ugrid_struct_t, delete_ugrid
+    use unstructured_mesh_m
     use vtk_importer_m
     implicit none
     type(vtk_importer_t) vtk_importer


### PR DESCRIPTION
ハーフフェイス構造体 (#27) 関連のアップデート. 
- construct_half_facesの引数から`cell_type_def`と`face_vert_def`を削除し, VTKフォーマットを強制させる. 
- `field_updater_t`のAPIの変更
- API変更に伴うPyPTSのライブラリの修正.
- 温度場の追加(`flow_field_t`, `ugrid_struct_t`). 
